### PR TITLE
Integrated data storage solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+## project specific ignored file
+!./data/.gitkeep
+./data/*
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -133,3 +138,5 @@ dmypy.json
 /.idea/modules.xml
 /.idea/report-text-extraction.iml
 /.idea/vcs.xml
+/.idea/misc.xml
+/.idea/inspectionProfiles/Project_Default.xml

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ cors = "*"
 flask-cors = "*"
 waitress = "*"
 pycld2 = {file = "https://github.com/aboSamoor/pycld2/zipball/e3ac86ed4d4902e912691c1531d0c5645382a726"}
+flask-httpauth = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65b97b3b4572b18cf57a02508f46801f35b984709ebad93587be9f8b8847466e"
+            "sha256": "9a6315242df1c4ee5a07518f7d33a8d70c09edea2c86d1753df44f9fb5417654"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -72,11 +72,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f",
-                "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"
+                "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8",
+                "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.3.1"
+            "version": "==3.3.2"
         },
         "flask": {
             "hashes": [
@@ -93,6 +93,14 @@
             ],
             "index": "pypi",
             "version": "==3.0.10"
+        },
+        "flask-httpauth": {
+            "hashes": [
+                "sha256:395040fda2854df800d15e84bc4a81a5f32f1d4a5e91eee554936f36f330aa29",
+                "sha256:e16067ba3378ea366edf8de4b9d55f38c0a0cbddefcc0f777a54b3fce1d99392"
+            ],
+            "index": "pypi",
+            "version": "==4.5.0"
         },
         "future": {
             "hashes": [
@@ -218,6 +226,7 @@
                 "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
                 "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
                 "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
                 "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
                 "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
                 "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
@@ -225,6 +234,7 @@
                 "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
                 "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
                 "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
                 "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
                 "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
                 "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
@@ -232,27 +242,36 @@
                 "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
                 "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
                 "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
                 "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
                 "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
                 "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
                 "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
                 "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
                 "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
                 "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
                 "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
                 "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
+                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
                 "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
                 "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
                 "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
                 "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
                 "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
                 "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
+                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
                 "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
                 "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
                 "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
                 "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
                 "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
                 "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
                 "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
                 "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
                 "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
@@ -260,10 +279,14 @@
                 "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
                 "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
                 "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
+                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
                 "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
                 "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
                 "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
                 "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
                 "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
                 "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
                 "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",

--- a/app.py
+++ b/app.py
@@ -1,21 +1,26 @@
 #!/usr/bin/python
 # -*- coding:utf-8 -*-
 
-from flask import Flask, request, jsonify, send_from_directory, redirect # , send_file
+from flask import Flask, request, jsonify, send_from_directory, redirect  # , send_file
 from flask_cors import CORS
-import pdf
+
 import lng
+import pdf
+import storage
 
 app = Flask(__name__)
 CORS(app)
+
 
 @app.route('/docs')
 def send_docs_root():
     return redirect("docs/index.html", code=308)
 
+
 @app.route('/docs/<path:path>')
 def send_docs(path):
     return send_from_directory('docs', path)
+
 
 @app.post("/extractor")
 def post_extractor():
@@ -34,8 +39,11 @@ def post_extractor():
 
     text = pdf.toText(file)
     lang = lng.detect(text)
-    
-    return '\n'.join([lang, text]), 200
+
+    uuid = storage.save_files(file, text)
+
+    return jsonify({'lang': lang, 'pdf': uuid + ".pdf", 'text': uuid + '.txt'}), 200
+
 
 def allowed_file(filename, allowed_extensions):
     return '.' in filename and \

--- a/app.py
+++ b/app.py
@@ -1,14 +1,17 @@
 #!/usr/bin/python
 # -*- coding:utf-8 -*-
+import os
 
 from flask import Flask, request, jsonify, send_from_directory, redirect  # , send_file
 from flask_cors import CORS
+from flask_httpauth import HTTPBasicAuth
 
 import lng
 import pdf
 import storage
 
 app = Flask(__name__)
+auth = HTTPBasicAuth()
 CORS(app)
 
 
@@ -23,6 +26,7 @@ def send_docs(path):
 
 
 @app.post("/extractor")
+@auth.login_required()
 def post_extractor():
     if 'file' not in request.files:
         return jsonify({'error': 'Bad Request', 'message': 'File is missing'}), 400
@@ -48,3 +52,10 @@ def post_extractor():
 def allowed_file(filename, allowed_extensions):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in allowed_extensions
+
+
+@auth.verify_password
+def authenticate(username, password):
+    assert ('BASIC_AUTH_USER' in os.environ)
+    assert ('BASIC_AUTH_PWD' in os.environ)
+    return (username == os.environ['BASIC_AUTH_USER']) and (password == os.environ['BASIC_AUTH_PWD'])

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
     environment:
       FLASK_ENV: development
       FLASK_APP: app.py
+      BASIC_AUTH_USER: bizres
+      BASIC_AUTH_PWD: secret
     ports:
       - 5000:5000
     volumes:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,91 +1,108 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-      "title": "PDF to text extractor",
-      "description": "Extracts plain text from provided PDF file",
-      "version": "1.0.0"
-    },
-    "paths": {
-      "/extractor": {
-        "post": {
-          "summary": "Uploads PDF file and retrieves extracted text as a file.",
-          "tags": [
-            "PDF"
-          ],
-          "requestBody": {
-            "$ref": "#/components/requestBodies/File"
-          },
-          "responses": {
-            "200": {
-              "description": "A TXT file.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "400": {
-              "$ref": "#/components/responses/ServerError"
-            },
-            "415": {
-              "$ref": "#/components/responses/ServerError"
-            },
-            "500": {
-              "$ref": "#/components/responses/ServerError"
-            }
-          }
-        }
-      }
-    },
-    "components": {
-      "requestBodies": {
-        "File": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary"
+  "openapi": "3.0.0",
+  "info": {
+    "title": "PDF to text extractor",
+    "description": "Extracts plain text from provided PDF file",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/extractor": {
+      "post": {
+        "summary": "Uploads PDF file and retrieves extracted text as a file.",
+        "tags": [
+          "PDF"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/File"
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a JSON object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lang": {
+                      "type": "string",
+                      "description": "The language code (ie. 'en', 'de')",
+                      "example": "de"
+                    },
+                    "pdf": {
+                      "type": "string",
+                      "description": "The pdf filename",
+                      "example": "cc596f51-032a-404f-8445-1e4e2ea9990a.pdf"
+                    },
+                    "text": {
+                      "type": "string",
+                      "description": "The extracted text filename",
+                      "example": "cc596f51-032a-404f-8445-1e4e2ea9990a.txt"
+                    }
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "responses": {
-        "ServerError": {
-          "description": "Server Error",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Error"
-              }
-            }
-          }
-        }
-      },
-      "schemas": {
-        "Error": {
-          "type": "object",
-          "properties": {
-            "error": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            }
           },
-          "required": [
-            "error",
-            "message"
-          ]
+          "400": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "415": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
         }
       }
     }
+  },
+  "components": {
+    "requestBodies": {
+      "File": {
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "ServerError": {
+        "description": "Server Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "message"
+        ]
+      }
+    }
   }
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -13,12 +13,24 @@ paths:
         $ref: '#/components/requestBodies/File'
       responses:
         '200':
-          description: A TXT file.
+          description: Returns a JSON object
           content:
-            text/plain:
-              schema: 
-                type: string
-                # format: binary
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lang:
+                    type: string
+                    description: The language code (ie. 'en', 'de')
+                    example: 'de'
+                  pdf:
+                    type: string
+                    description: The pdf filename
+                    example: 'cc596f51-032a-404f-8445-1e4e2ea9990a.pdf'
+                  text:
+                    type: string
+                    description: The extracted text filename
+                    example: 'cc596f51-032a-404f-8445-1e4e2ea9990a.txt'
         '400':
           $ref: '#/components/responses/ServerError'
         '415':

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+import os
+import uuid
+
+DEFAULT_STORAGE_DIR = './data'
+
+
+def save_files(pdf, text):
+    digest = uuid.uuid4()
+    save_text(digest, text)
+    save_pdf(digest, pdf)
+    return str(digest)
+
+
+def save_pdf(digest, file):
+    file.save(create_file_name(digest, 'pdf'))
+
+
+def save_text(digest, file):
+    write_file(file, create_file_name(digest, 'txt'))
+
+
+def create_file_name(digest, extension):
+    storage_dir = os.environ['STORAGE_DIR'] if 'STORAGE_DIR' in os.environ else DEFAULT_STORAGE_DIR
+    return "{dir}/{hash}.{ext}".format(dir=storage_dir, hash=digest, ext=extension)
+
+
+def write_file(file, file_name):
+    with open(file_name, 'w') as f:
+        f.write(file)


### PR DESCRIPTION
- Saving the pdf and extracted text in data storage
- Added a new env variable for data storage location (defaults to '<ROOT>/data')
- Returning language, pdf and text filenames as json object in POST request

Already deployed this solution to production for testing:
- https://extractor.bizres.ch/docs/index.html#/PDF/post_extractor

The pdf and text files are succesfully saved in our NFS storage folder.