### PR TITLE
Service for uploading the report PDFs in Hidora, with metdata #74

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,42 +6,15 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/extractor": {
-      "post": {
-        "summary": "Uploads PDF file and retrieves extracted text as a file.",
+    "/extract": {
+      "get": {
+        "summary": "Starts Report extraction. Downloads PDFs from Airtable, extracts text, and generates meta data. Resulting PDF, TXT, and JSON files are stored then locally.",
         "tags": [
           "PDF"
         ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/File"
-        },
         "responses": {
-          "200": {
-            "description": "Returns a JSON object",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "lang": {
-                      "type": "string",
-                      "description": "The language code (ie. 'en', 'de')",
-                      "example": "de"
-                    },
-                    "pdf": {
-                      "type": "string",
-                      "description": "The pdf filename",
-                      "example": "cc596f51-032a-404f-8445-1e4e2ea9990a.pdf"
-                    },
-                    "text": {
-                      "type": "string",
-                      "description": "The extracted text filename",
-                      "example": "cc596f51-032a-404f-8445-1e4e2ea9990a.txt"
-                    }
-                  }
-                }
-              }
-            }
+          "202": {
+            "description": "Accepted. Returns nothing. Starts Report extraction in background."
           },
           "400": {
             "$ref": "#/components/responses/ServerError"
@@ -57,24 +30,6 @@
     }
   },
   "components": {
-    "requestBodies": {
-      "File": {
-        "required": true,
-        "content": {
-          "multipart/form-data": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "file": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "responses": {
       "ServerError": {
         "description": "Server Error",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,33 +4,14 @@ info:
   description: Extracts plain text from provided PDF file
   version: 1.0.0
 paths:
-  /extractor:
-    post:
-      summary: Uploads PDF file and retrieves extracted text as a file.
+  /extract:
+    get:
+      summary: Starts Report extraction. Downloads PDFs from Airtable, extracts text, and generates meta data. Resulting PDF, TXT, and JSON files are stored then locally.
       tags:
         - PDF
-      requestBody:
-        $ref: '#/components/requestBodies/File'
       responses:
-        '200':
-          description: Returns a JSON object
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  lang:
-                    type: string
-                    description: The language code (ie. 'en', 'de')
-                    example: 'de'
-                  pdf:
-                    type: string
-                    description: The pdf filename
-                    example: 'cc596f51-032a-404f-8445-1e4e2ea9990a.pdf'
-                  text:
-                    type: string
-                    description: The extracted text filename
-                    example: 'cc596f51-032a-404f-8445-1e4e2ea9990a.txt'
+        '202':
+          description: Accepted. Returns nothing. Starts Report extraction in background.
         '400':
           $ref: '#/components/responses/ServerError'
         '415':
@@ -38,18 +19,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 components:
-  requestBodies:
-    File:
-      required: true
-      content:
-        multipart/form-data:
-          schema:
-            type: object
-            properties:
-              file:
-                type: string
-                format: binary
-
   responses:
     ServerError:
       description: Server Error

--- a/services.py
+++ b/services.py
@@ -9,17 +9,19 @@ import storage
 import urllib3
 import pdf
 from pathlib import Path
+import uuid
+import json
 
 
 def airtable_pdfs_to_local_txt():
     airtable_config = config.airtable()
-    print(airtable_config)
+    # print(airtable_config)
 
-    url = 'https://api.airtable.com/v0/' + airtable_config.base_id + '/' + 'CrawlResults' + '?fields%5B%5D=PDF'
+    url = 'https://api.airtable.com/v0/' + airtable_config.base_id + '/' + 'CrawlResults' + '?fields%5B%5D=PDF&fields%5B%5D=ExtractedID'
 
     headers = {"Authorization": "Bearer " + airtable_config.api_key}
 
-    target_dir = os.path.join(storage.dir(), 'txt')
+    target_dirs = storage.dirs()
 
     # collect all records first as otherwise offset is not valid after certain amount of time
     records = []
@@ -46,39 +48,120 @@ def airtable_pdfs_to_local_txt():
             # no more pages
             break
 
-
     print('Records to process', len(records))
 
-    # process all single records
-    [process_record(rec, target_dir) for rec in records]
+    # patch airtable with bulk updates x10 records
+    payload = None
+    i = 0
+    for rec in records:
+        res = process_record(rec, target_dirs)
+
+        if not res is None:
+            if payload is None:
+                payload = {'records': []}
+
+            fields = {}
+            if 'id' in res:
+                fields['ExtractedID'] = res['id']
+            if 'status' in res:
+                fields['ExtractedStatus'] = res['status']
+
+            if len(fields) > 0:
+                i = i + 1
+                payload['records'].append({
+                            'id': res['air_id'],
+                            'fields': fields,
+                        }
+                )
+
+            if 10 == i:
+                i = 0
+                flush(payload, airtable_config)
+                payload = None
+
+    if not payload is None:
+        if len(payload['records']) > 0:
+            flush(payload, airtable_config)
+
+    print('Done')
+        
+
+def flush(payload, airtable_config):
+    headers = {"Authorization": "Bearer " + airtable_config.api_key}
+    url_patch = "https://api.airtable.com/v0/" + airtable_config.base_id + "/" + 'CrawlResults'
+    resp = requests.patch(url_patch, json=payload, headers=headers)
+    resp.raise_for_status()
+    # print(resp.json())
 
 
-def process_record(rec, target_dir):
+def process_record(rec, target_dirs):
     print('----------')
-    id = rec['id']
-    print(id)
-
-    filepath = os.path.join(target_dir, id + '.txt')
-    if os.path.isfile(filepath):
-        # already exists -> skip
-        return
+    air_id = rec['id']
+    print(air_id)
+    res = {'air_id': air_id}
 
     fields = rec['fields']
 
-    if not 'PDF' in fields:
-        return
+    id = ''
+    e_id = ''
+    pdf_file_path = None
+    # if pdf was already extracted on another client - reuse id
+    if 'ExtractedID' in fields:
+        id = fields['ExtractedID']
+        e_id = id
+        # print('ExtractedId', id)
+        pdf_file_path = os.path.join(target_dirs.pdf, id + '.pdf')
+        if os.path.isfile(pdf_file_path):
+            # already extracted
+            return None
 
-    text = fetch_pdf(fields)
+    # get unique not yet existing id
+    if '' == id:
+        while True:
+            id = str(uuid.uuid4())
+            pdf_file_path = os.path.join(target_dirs.pdf, id + '.pdf')
+            if not os.path.isfile(pdf_file_path):
+                break
+    print(id)
+
+    if not 'PDF' in fields:
+        # respond with code 'NO PDF'
+        res['status'] = '01 - No PDF'
+        return res
+
+    pdf_bytes, text = fetch_pdf(fields)
 
     if text is None:
-        return
+        # respond with code 'Failed to extract text'
+        res['status'] = '02 - Failed to extract text'
+        return res
 
-    directory = os.path.dirname(filepath)
-    Path(directory).mkdir(parents=True, exist_ok=True)
+    storage.ensure_path(pdf_file_path)
+    pdf_bytes.seek(0)
+    with open(pdf_file_path, 'wb') as f:
+        f.write(pdf_bytes.getbuffer())
 
-    with open(filepath, 'w', encoding="utf8") as f:
+    txt_file_path = os.path.join(target_dirs.txt, id + '.txt')
+    storage.ensure_path(txt_file_path)
+    with open(txt_file_path, 'w', encoding='utf8') as f:
         f.write(text)
     
+    meta = {'air_id': air_id,
+            'id': id,
+            'filename': fields['PDF'][0]['filename']}
+    meta_file_path = os.path.join(target_dirs.meta, id + '.json')
+    storage.ensure_path(meta_file_path)
+    with open(meta_file_path, 'w', encoding='utf8') as f:
+        json.dump(meta, f, ensure_ascii=False, indent=4)
+
+    if id == e_id:
+        # reused existing id
+        return
+
+    # upload id to airtable
+    res['id'] = id
+    return res
+
 
 def fetch_pdf(fields):
     url = fields['PDF'][0]['url']
@@ -86,8 +169,6 @@ def fetch_pdf(fields):
     http = urllib3.PoolManager()
     r = http.request('GET', url)
     print(r.status)
-    # print(type(r.data))
-    file = io.BytesIO(r.data)
-    # print(type(file))
-    text = pdf.to_text(file)
-    return text
+    pdf_bytes = io.BytesIO(r.data)
+    text = pdf.to_text(pdf_bytes)
+    return pdf_bytes, text

--- a/storage.py
+++ b/storage.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding:utf-8 -*-
 import os
-import uuid
+from collections import namedtuple
+from pathlib import Path
 
 DEFAULT_STORAGE_DIR = './data'
 
@@ -9,27 +10,19 @@ DEFAULT_STORAGE_DIR = './data'
 def dir():
     return os.environ['STORAGE_DIR'] if 'STORAGE_DIR' in os.environ else DEFAULT_STORAGE_DIR
 
+def txt_dir():
+    return os.path.join(dir(), 'txt')
 
-def save_files(pdf, text):
-    digest = uuid.uuid4()
-    save_text(digest, text)
-    save_pdf(digest, pdf)
-    return str(digest)
+def pdf_dir():
+    return os.path.join(dir(), 'pdf')
 
+def meta_dir():
+    return os.path.join(dir(), 'meta')
 
-def save_pdf(digest, file):
-    file.save(create_file_name(digest, 'pdf'))
+def dirs():
+    DirsTuple = namedtuple('Dirs', 'pdf txt meta')
+    return DirsTuple(pdf=pdf_dir(), txt=txt_dir(), meta=meta_dir())
 
-
-def save_text(digest, file):
-    write_file(file, create_file_name(digest, 'txt'))
-
-
-def create_file_name(digest, extension):
-    storage_dir = os.environ['STORAGE_DIR'] if 'STORAGE_DIR' in os.environ else DEFAULT_STORAGE_DIR
-    return "{dir}/{hash}.{ext}".format(dir=storage_dir, hash=digest, ext=extension)
-
-
-def write_file(file, file_name):
-    with open(file_name, 'w', encoding="utf8") as f:
-        f.write(file)
+def ensure_path(file_path):
+    directory = os.path.dirname(file_path)
+    Path(directory).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Old REST API services removed.

New REST API service GET "/extract":
- reads parameters from environment (AIRTABLE_API_KEY, AIRTABLE_BASE_ID) of config.ini (api_key, base_id)
- reads all PDFs from Airtable, saves PDFs locally in {STORAGE_DIR}/pdf (by default STORAGE_DIR='./data')
- extracts text and saves TXT files locally in {STORAGE_DIR}/txt (by default STORAGE_DIR='./data')
- creates META files and saves JSON files locally in {STORAGE_DIR}/meta (by default STORAGE_DIR='./data')
- META files contain: air_id (airtable id), id (random uuid), filename (original filename)
- skips already extracted files - if PDF file with ExtractedID is found locally
- filenames: {id}.pdf + {id}.txt + {id}.json

Service is protected with basic auth.

OpenAPI (Swagger UI 3.0) documentation is updated.